### PR TITLE
Fixed issue with same `options` being used for all requests

### DIFF
--- a/src/broken-link.js
+++ b/src/broken-link.js
@@ -9,7 +9,7 @@ var reportStatusCode = require('./report-status-code');
 var reportSoft404 = require('./report-soft-404.js');
 
 function brokenLink(url, options) {
-  options = objectAssign(defaults, options, {uri: url});
+  options = objectAssign({}, defaults, options, {uri: url});
 
   return new Promise(function(resolve, reject) {
     request(options)


### PR DESCRIPTION
I was using this lib for a ton of links in succession and getting false positives. After digging I discovered that `options` was changing values between `options = objectAssign([...])` and the inside of `on("response", [...])`.

According to the [docs for Object.assign](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign):

> Syntax: Object.assign(target, ...sources)
> Return value: The target object gets returned.

So `options = objectAssign(defaults, options, {uri: url});` would actually be returning `defaults`, not a new separate object for each request.
